### PR TITLE
Add a serde feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ edition = "2018"
 
 [dependencies]
 smallvec = { version = "1.0.0" }
+serde = { version = "1.0", default-features = false, features = ["alloc", "derive"], optional = true }
 
 [features]
 std = []

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,24 +2,29 @@
 #![warn(missing_docs)]
 //! A simple and generic implementation of an immutable interval tree.
 
-#[cfg(feature = "std")]
-extern crate std;
 #[cfg(not(feature = "std"))]
 extern crate alloc;
-
-use core::ops::Range;
-use core::iter::FromIterator;
-use core::fmt::{Debug, Formatter, Result as FmtResult};
-use core::slice::Iter;
-use core::cmp;
+#[cfg(feature = "serde")]
+extern crate serde;
 #[cfg(feature = "std")]
-use std::vec::{Vec, IntoIter};
+extern crate std;
+
 #[cfg(not(feature = "std"))]
-use alloc::vec::{Vec, IntoIter};
+use alloc::vec::{IntoIter, Vec};
+use core::cmp;
+use core::fmt::{Debug, Formatter, Result as FmtResult};
+use core::iter::FromIterator;
+use core::ops::Range;
+use core::slice::Iter;
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 use smallvec::SmallVec;
+#[cfg(feature = "std")]
+use std::vec::{IntoIter, Vec};
 
 /// An element of an interval tree.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Element<K, V> {
     /// The range associated with this element.
     pub range: Range<K>,
@@ -35,7 +40,8 @@ impl<K, V> From<(Range<K>, V)> for Element<K, V> {
 }
 
 #[derive(Clone, Debug, Hash)]
-struct Node<K, V>{
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+struct Node<K, V> {
     element: Element<K, V>,
     max: K,
 }
@@ -45,14 +51,21 @@ struct Node<K, V>{
 /// To build it, always use `FromIterator`. This is not very optimized
 /// as it takes `O(log n)` stack (it uses recursion) but runs in `O(n log n)`.
 #[derive(Clone, Debug, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct IntervalTree<K, V> {
     data: Vec<Node<K, V>>,
 }
 
 impl<K: Ord + Clone, V, I: Into<Element<K, V>>> FromIterator<I> for IntervalTree<K, V> {
     fn from_iter<T: IntoIterator<Item = I>>(iter: T) -> Self {
-        let mut nodes: Vec<_> = iter.into_iter().map(|i| i.into())
-            .map(|element| Node { max: element.range.end.clone(), element }).collect();
+        let mut nodes: Vec<_> = iter
+            .into_iter()
+            .map(|i| i.into())
+            .map(|element| Node {
+                max: element.range.end.clone(),
+                element,
+            })
+            .collect();
 
         nodes.sort_unstable_by(|a, b| a.element.range.start.cmp(&b.element.range.start));
 
@@ -168,7 +181,7 @@ impl<K: Ord, V> IntervalTree<K, V> {
     ///
     /// This is currently identical to `IntervalTree::iter` because the internal structure
     /// is already sorted this way, but may not be in the future.
-    pub fn iter_sorted(&self) -> impl Iterator<Item=&Element<K, V>> {
+    pub fn iter_sorted(&self) -> impl Iterator<Item = &Element<K, V>> {
         TreeIter(self.data.iter())
     }
 }
@@ -233,7 +246,7 @@ impl<'a, K: Ord, V> Iterator for QueryIter<'a, K, V> {
 
     fn next(&mut self) -> Option<&'a Element<K, V>> {
         while let Some((s, l)) = self.todo.pop() {
-            let i = s + l/2;
+            let i = s + l / 2;
 
             let node = &self.tree.data[i];
             if self.query.point() < &node.max {
@@ -267,13 +280,13 @@ impl<'a, K: Ord, V> Iterator for QueryIter<'a, K, V> {
 
 #[cfg(test)]
 mod tests {
-    use core::iter;
     use super::*;
+    use core::iter;
 
     fn verify(tree: &IntervalTree<u32, u32>, i: u32, expected: &[u32]) {
         let mut v1: Vec<_> = tree.query_point(i).map(|x| x.value).collect();
         v1.sort();
-        let mut v2: Vec<_> = tree.query(i..(i+1)).map(|x| x.value).collect();
+        let mut v2: Vec<_> = tree.query(i..(i + 1)).map(|x| x.value).collect();
         v2.sort();
         assert_eq!(v1, expected);
         assert_eq!(v2, expected);
@@ -290,8 +303,10 @@ mod tests {
             (5..8, 6),
             (4..5, 7),
             (2..7, 8),
-        ].iter().cloned().collect();
-
+        ]
+        .iter()
+        .cloned()
+        .collect();
 
         verify(&tree, 0, &[1]);
         verify(&tree, 1, &[1, 2]);


### PR DESCRIPTION
Hi,
In this PR I add an optional serde feature to make IntervalTree serializable without std.
I suggest you to bump the version and update crates.io.